### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,59 +1,25 @@
 {
   "extends": "nx/presets/npm.json",
-  "workspaceLayout": {
-    "libsDir": "packages",
-    "appsDir": ""
-  },
+  "workspaceLayout": { "libsDir": "packages", "appsDir": "" },
   "targetDependencies": {
-    "build": [
-      {
-        "target": "build",
-        "projects": "dependencies"
-      }
-    ],
-    "prepare": [
-      {
-        "target": "prepare",
-        "projects": "dependencies"
-      }
-    ],
-    "package": [
-      {
-        "target": "package",
-        "projects": "dependencies"
-      }
-    ]
+    "build": [{ "target": "build", "projects": "dependencies" }],
+    "prepare": [{ "target": "prepare", "projects": "dependencies" }],
+    "package": [{ "target": "package", "projects": "dependencies" }]
   },
   "defaultProject": "examples",
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
-    "build": {
-      "dependsOn": ["^build"],
-      "cache": true
-    },
-    "prepare": {
-      "dependsOn": ["^prepare"],
-      "cache": true
-    },
+    "build": { "dependsOn": ["^build"], "cache": true },
+    "prepare": { "dependsOn": ["^prepare"], "cache": true },
     "@nx/jest:jest": {
       "cache": true,
       "inputs": ["default", "^default", "{workspaceRoot}/jest.preset.js"],
-      "options": {
-        "passWithNoTests": true
-      },
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true
-        }
-      }
+      "options": { "passWithNoTests": true },
+      "configurations": { "ci": { "ci": true, "codeCoverage": true } }
     },
-    "@nx/eslint:lint": {
-      "inputs": ["default", "{workspaceRoot}/.eslintrc.json"],
-      "cache": true
-    }
+    "@nx/eslint:lint": { "inputs": ["default", "{workspaceRoot}/.eslintrc.json"], "cache": true }
   },
-  "nxCloudAccessToken": "YWExNTY0MWYtYWMzNy00ZWZkLWIzMWEtMGYzYWY4YWRmMDE1fHJlYWQtd3JpdGU=",
+  "nxCloudAccessToken": "NDUzYjNkZmItN2Q3MS00YzczLWIwYmEtZmMwZmIxMmEzZDA4fHJlYWQtd3JpdGU=",
   "useInferencePlugins": false,
   "defaultBase": "master"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/66f429174044308b8969bfa4/workspaces/66f42a0be0e93f8040b50591

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.